### PR TITLE
Fix metadata context not initialized when using resolve plugin

### DIFF
--- a/plugin/archivingcache/setup.go
+++ b/plugin/archivingcache/setup.go
@@ -63,7 +63,7 @@ func (a *ArchivingCache) OnShutdown() (err error) {
 	if a.logWriter != nil {
 		_ = a.contentWriter.Close()
 	}
-	if a.logWriter == nil {
+	if a.logWriter != nil {
 		_ = a.logWriter.Close()
 	}
 	return


### PR DESCRIPTION
This PR fixes the metadata context not being initialized when resolving through the resolve plugin.

A bug in the shutdown hook of the archivingcache plugin is also fixed.